### PR TITLE
28511 | Hid Export Tab for Form Import Utility

### DIFF
--- a/SOAP Web Service API Examples/VisualVault.Forms.Import/ImportFormData.Designer.cs
+++ b/SOAP Web Service API Examples/VisualVault.Forms.Import/ImportFormData.Designer.cs
@@ -396,7 +396,7 @@ namespace VisualVault.Forms.Import
             // 
             this.tabControl1.Controls.Add(this.tabPage1);
             this.tabControl1.Controls.Add(this.tabPage2);
-            this.tabControl1.Controls.Add(this.tabPage3);
+            //this.tabControl1.Controls.Add(this.tabPage3); //hide export forms tab
             this.tabControl1.Controls.Add(this.tabPage4);
             //this.tabControl1.Controls.Add(this.tabPage5); //hide delete forms tab
             //this.tabControl1.Controls.Add(this.tabPage6); //hide create users tab

--- a/SOAP Web Service API Examples/VisualVault.Forms.Import/ImportFormData.cs
+++ b/SOAP Web Service API Examples/VisualVault.Forms.Import/ImportFormData.cs
@@ -71,7 +71,7 @@ namespace VisualVault.Forms.Import
             _actionType = FormImportActionType.GetTemplateList;
 
             tabPage2.Enabled = false;
-            tabPage3.Enabled = false;
+            //tabPage3.Enabled = false; /* Export Form Data tab hidden 2024-12-02 */
             tabPage5.Enabled = false;           
 
             ShowFirstProfile();
@@ -507,7 +507,7 @@ namespace VisualVault.Forms.Import
         private void EnableAllControls()
         {
             tabPage2.Enabled = true;
-            tabPage3.Enabled = true;
+            //tabPage3.Enabled = true;   /* Export Form Data tab hidden 2024-12-02 */
             tabPage5.Enabled = true;            
         }
 

--- a/SOAP Web Service API Examples/VisualVault.Forms.Import/Properties/AssemblyInfo.cs
+++ b/SOAP Web Service API Examples/VisualVault.Forms.Import/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("3.0.0.0")]
-[assembly: AssemblyFileVersion("3.0.0.0")]
+[assembly: AssemblyVersion("3.0.1.0")]
+[assembly: AssemblyFileVersion("3.0.1.0")]


### PR DESCRIPTION
- Commented out "Export Form Data" tab control (`tabPage3`).
- Updated Form Import Utility to version `3.0.1.0`.